### PR TITLE
Add Elixir syntax styles

### DIFF
--- a/index.less
+++ b/index.less
@@ -10,7 +10,7 @@
 @import 'syntax/cpp';
 @import 'syntax/cs';
 @import 'syntax/css';
-@import 'styles/syntax/elixir';
+@import 'syntax/elixir';
 @import 'syntax/gfm';
 @import 'syntax/go';
 @import 'syntax/html';

--- a/index.less
+++ b/index.less
@@ -10,6 +10,7 @@
 @import 'syntax/cpp';
 @import 'syntax/cs';
 @import 'syntax/css';
+@import 'syntax/elixir';
 @import 'syntax/gfm';
 @import 'syntax/go';
 @import 'syntax/html';

--- a/index.less
+++ b/index.less
@@ -10,7 +10,7 @@
 @import 'syntax/cpp';
 @import 'syntax/cs';
 @import 'syntax/css';
-@import 'syntax/elixir';
+@import 'styles/syntax/elixir';
 @import 'syntax/gfm';
 @import 'syntax/go';
 @import 'syntax/html';

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -10,9 +10,9 @@
 @syntax-brightness:   20%;
 
 // Monochrome
-@mono-1: hsl(@syntax-hue,  0%, 96%);
+@mono-1: hsl(@syntax-hue,  0%, 90%);
 @mono-2: hsl(@syntax-hue, 24%, 72%);
-@mono-3: hsl(@syntax-hue, 12%, 48%);
+@mono-3: hsl(@syntax-hue, 12%, 40%);
 
 // Colors
 @hue-1:   @oc-blue-3;

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -10,9 +10,9 @@
 @syntax-brightness:   20%;
 
 // Monochrome
-@mono-1: hsl(@syntax-hue,  0%, 90%);
+@mono-1: hsl(@syntax-hue,  0%, 96%);
 @mono-2: hsl(@syntax-hue, 24%, 72%);
-@mono-3: hsl(@syntax-hue, 12%, 40%);
+@mono-3: hsl(@syntax-hue, 12%, 48%);
 
 // Colors
 @hue-1:   @oc-blue-3;

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -1,0 +1,46 @@
+
+/* SYNTAX: ELIXIR */
+.syntax--source.syntax--elixir {
+  .syntax--regexp.syntax--section,
+  .syntax--regexp.syntax--string,
+  .syntax--constant.syntax--language,
+  .syntax--constant.syntax--numeric,
+  .syntax--constant.syntax--definition,
+  .syntax--function,
+  .syntax--quoted{
+    color: @hue-1;
+    > .syntax--punctuation{
+      color: @hue-1;
+    }
+  }
+  .syntax--variable.syntax--definition,
+  .syntax--variable.syntax--anonymous{
+    color: @hue-3;
+  }
+  .syntax--variable.syntax--constant,
+  .syntax--entity.syntax--name.syntax--type {
+    color: @hue-4;
+  }
+  .syntax--keyword.syntax--special-method,
+  .syntax--embedded.syntax--section.syntax--punctuation,
+  .syntax--embedded.syntax--source.syntax--empty,
+  .syntax--readwrite.syntax--module,
+  .syntax--storage.syntax--type{
+    color: @hue-5;
+    > .syntax--punctuation {
+      color: @hue-5;
+    }
+  }
+  .syntax--separator,
+  .syntax--keyword.syntax--operator  {
+    color: @hue-6;
+  }
+  .syntax--array,
+  .syntax--scope,
+  .syntax--section {
+    color: @mono-2;
+  }
+  .syntax--source.syntax--embedded.syntax--source {
+    color: @mono-1;
+  }
+}

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -40,7 +40,7 @@
   .syntax--scope,
   .syntax--section,
   .syntax--keyword.syntax--operator {
-    color: @hue-5-2;
+    color: @mono-2;
   }
   .syntax--source {
     color: @mono-1;

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -2,32 +2,32 @@
 /* SYNTAX: ELIXIR */
 .syntax--source.syntax--elixir {
   .syntax--constant.syntax--definition,
-  .syntax--embedded.syntax--punctuation,
   .syntax--constant.syntax--language,
   .syntax--function {
     color: @hue-1;
-    .syntax--empty {
-      color: @hue-1;
-    }
   }
   .syntax--variable.syntax--definition,
-  .syntax--variable.syntax--anonymous{
+  .syntax--variable.syntax--anonymous,
+  .syntax--embedded.syntax--punctuation {
     color: @hue-3;
+    .syntax--empty {
+      color: @hue-3;
+    }
   }
   .syntax--keyword.syntax--special-method,
   .syntax--readwrite.syntax--module,
   .syntax--storage.syntax--type{
-    color: @hue-4;
+    color: @hue-5;
     > .syntax--punctuation {
-      color: @hue-4;
+      color: @hue-5;
     }
   }
   .syntax--regexp.syntax--section,
   .syntax--regexp.syntax--string,
   .syntax--quoted{
-    color: @hue-5;
+    color: @hue-4;
     > .syntax--punctuation{
-      color: @hue-5;
+      color: @hue-4;
     }
   }
   .syntax--separator,
@@ -40,7 +40,7 @@
   .syntax--scope,
   .syntax--section,
   .syntax--keyword.syntax--operator {
-    color: @mono-2;
+    color: @hue-5-2;
   }
   .syntax--source {
     color: @mono-1;

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -1,15 +1,11 @@
 
 /* SYNTAX: ELIXIR */
 .syntax--source.syntax--elixir {
-  .syntax--regexp.syntax--section,
-  .syntax--regexp.syntax--string,
-  .syntax--constant.syntax--language,
-  .syntax--constant.syntax--numeric,
   .syntax--constant.syntax--definition,
-  .syntax--function,
-  .syntax--quoted{
+  .syntax--embedded.syntax--punctuation,
+  .syntax--function {
     color: @hue-1;
-    > .syntax--punctuation{
+    .syntax--empty {
       color: @hue-1;
     }
   }
@@ -17,30 +13,36 @@
   .syntax--variable.syntax--anonymous{
     color: @hue-3;
   }
-  .syntax--variable.syntax--constant,
-  .syntax--entity.syntax--name.syntax--type {
-    color: @hue-4;
-  }
   .syntax--keyword.syntax--special-method,
-  .syntax--embedded.syntax--section.syntax--punctuation,
-  .syntax--embedded.syntax--source.syntax--empty,
   .syntax--readwrite.syntax--module,
   .syntax--storage.syntax--type{
-    color: @hue-5;
+    color: @hue-4;
     > .syntax--punctuation {
+      color: @hue-4;
+    }
+  }
+  .syntax--regexp.syntax--section,
+  .syntax--regexp.syntax--string,
+  .syntax--constant.syntax--language,
+  .syntax--quoted{
+    color: @hue-5;
+    > .syntax--punctuation{
       color: @hue-5;
     }
   }
   .syntax--separator,
-  .syntax--keyword.syntax--operator  {
+  .syntax--variable.syntax--constant,
+  .syntax--entity.syntax--name.syntax--type,
+  .syntax--constant.syntax--numeric {
     color: @hue-6;
   }
   .syntax--array,
   .syntax--scope,
-  .syntax--section {
+  .syntax--section,
+  .syntax--keyword.syntax--operator {
     color: @mono-2;
   }
-  .syntax--source.syntax--embedded.syntax--source {
+  .syntax--source {
     color: @mono-1;
   }
 }

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -3,6 +3,7 @@
 .syntax--source.syntax--elixir {
   .syntax--constant.syntax--definition,
   .syntax--embedded.syntax--punctuation,
+  .syntax--constant.syntax--language,
   .syntax--function {
     color: @hue-1;
     .syntax--empty {
@@ -23,7 +24,6 @@
   }
   .syntax--regexp.syntax--section,
   .syntax--regexp.syntax--string,
-  .syntax--constant.syntax--language,
   .syntax--quoted{
     color: @hue-5;
     > .syntax--punctuation{


### PR DESCRIPTION
## Description of the Change

**Improved Elixir syntax highlighting** 
- Operators and structure (tuples, arrays...) now dimmed_(@mono-2)_
   - _The heavy use operators in elixir combined with the fact that functions can have special characters such as  `.empty?` or special meaning such as `^pinned` means that using different colors for operators and functions improves readability a bit._
- Atoms (& functions) now have their own color _(@oc-blue-3)_
- Strings/charlists/regex now have their own color _(@oc-pink-4)_
- Strings/charlists/regex have normal highlighting inside interpolation (basically a bugfix)
-  Improved consistency of module highlighting _(@oc-orange-4)_
   - _Module names don't always have the same color depending on the context. Module Definitions are orange while import and usage are yellow. This is fixed by making all instances of modules orange._ 
- Changed color of importing functions to match module attributes (@oc-yellow-3)
  -  _Importing functions such as `[use, require, import, alias]` are most often placed alongside module attributes at the start of modules/functions. They both serve in a general sense as elixir's tools setup for module/function (constants, docs, imports, alias, and so on) so might as well have consistent coloring._

## Issues

`@import 'syntax/elixir';` seems to be throwing errors (file not found).
Changing this to `styles/syntax/elixir` fixes the problem, but isn't consistant with the other imports in `index.less`. 

![a](https://cdn.discordapp.com/attachments/227112710435766273/331148775135641601/unknown.png)
